### PR TITLE
[Draft] Add support for new index4 parameters

### DIFF
--- a/flutter_plugin/DLC_FUNCTIONS_GUIDE.md
+++ b/flutter_plugin/DLC_FUNCTIONS_GUIDE.md
@@ -71,7 +71,7 @@ final address = await DlcWallet.getAddress(0);
 ```dart
 final signature = await DlcWallet.signHashEcdsa(
   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  0,
+  0, 0,
   pubkey
 );
 ```
@@ -114,6 +114,7 @@ final signatures = await DlcWallet.createCetAdaptorSigs(
   digitStringTemplate: 'BTCUSD',
   oraclePublicKey: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
   signingKeyIndex: 0,
+  signingKeyIndex4: 0,
   signingPublicKey: await DlcWallet.getPublicKey(0),
   nonces: ['nonce1', 'nonce2'],
   intervalWildcards: ['50000-60000', '60000-70000'],
@@ -156,7 +157,7 @@ final xpub = await DlcWallet.initWithEntropy(entropy, "signet");
 final addresses = await DlcWallet.generateAddresses(10);
 
 // Sign transaction
-final signature = await DlcWallet.signTransaction(txHash, keyIndex);
+final signature = await DlcWallet.signTransaction(txHash, keyIndex, keyIndex4);
 ```
 
 ### **2. DLC Contract Creation**
@@ -183,13 +184,13 @@ final nonces = dlcSetup['nonces'];
 // Sign Bitcoin transaction
 final txSignature = await DlcWallet.signTransaction(
   transactionHash,
-  keyIndex
+  keyIndex, keyIndex4,
 );
 
 // Sign arbitrary hash
 final hashSignature = await DlcWallet.signHashEcdsa(
   messageHash,
-  keyIndex,
+  keyIndex, keyIndex4,
   publicKey
 );
 ```

--- a/flutter_plugin/flutter_plugin/example/lib/main.dart
+++ b/flutter_plugin/flutter_plugin/example/lib/main.dart
@@ -121,10 +121,12 @@ class _WalletScreenState extends State<WalletScreen> with TickerProviderStateMix
 
     try {
       final index = int.parse(_indexController.text);
+      final index4 = 0;
       final publicKey = await DlcWallet.getPublicKey(index);
       final signature = await DlcWallet.signHashEcdsa(
         _hashController.text,
         index,
+        index4,
         publicKey,
       );
 
@@ -162,6 +164,7 @@ class _WalletScreenState extends State<WalletScreen> with TickerProviderStateMix
       final signature = await DlcWallet.signTransaction(
         _hashController.text,
         int.parse(_indexController.text),
+        0,
       );
 
       _showResult('Transaction Signature', signature);
@@ -226,6 +229,7 @@ class _WalletScreenState extends State<WalletScreen> with TickerProviderStateMix
         digitStringTemplate: 'BTCUSD',
         oraclePublicKey: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
         signingKeyIndex: int.parse(_indexController.text),
+        signingKeyIndex4: 0,
         signingPublicKey: await DlcWallet.getPublicKey(int.parse(_indexController.text)),
         nonces: [
           '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',

--- a/flutter_plugin/flutter_plugin/lib/dlc_wallet.dart
+++ b/flutter_plugin/flutter_plugin/lib/dlc_wallet.dart
@@ -229,13 +229,14 @@ class DlcWallet {
   /// Sign hash with ECDSA
   /// Used for: Transaction signing, message authentication
   static Future<String> signHashEcdsa(
-      String hash, int signerIndex, String signerPubkey) async {
+      String hash, int signerIndex, int signerIndex4, String signerPubkey) async {
     if (Platform.isIOS) {
       // Use method channel for iOS
       try {
         final result = await _channel.invokeMethod('signHashEcdsa', {
           'hash': hash,
           'signerIndex': signerIndex,
+          'signerIndex4': signerIndex4,
           'signerPubkey': signerPubkey,
         });
         return result.toString();
@@ -301,6 +302,7 @@ class DlcWallet {
     required String digitStringTemplate,
     required String oraclePublicKey,
     required int signingKeyIndex,
+    required int signingKeyIndex4,
     required String signingPublicKey,
     required List<String> nonces,
     required List<String> intervalWildcards,
@@ -315,6 +317,7 @@ class DlcWallet {
           'digitStringTemplate': digitStringTemplate,
           'oraclePublicKey': oraclePublicKey,
           'signingKeyIndex': signingKeyIndex,
+          'signingKeyIndex4': signingKeyIndex4,
           'signingPublicKey': signingPublicKey,
           'nonces': nonces,
           'intervalWildcards': intervalWildcards,
@@ -353,7 +356,7 @@ class DlcWallet {
           numCets,
           digitStringTemplatePtr,
           oraclePublicKeyPtr,
-          0,
+          signingKeyIndex4,
           signingKeyIndex,
           signingPublicKeyPtr,
           noncesPtr,
@@ -451,9 +454,9 @@ class DlcWallet {
 
   /// Sign a Bitcoin transaction hash
   /// Used for: Transaction signing in wallet applications
-  static Future<String> signTransaction(String txHash, int keyIndex) async {
+  static Future<String> signTransaction(String txHash, int keyIndex, int keyIndex4) async {
     final publicKey = await getPublicKey(keyIndex);
-    return await signHashEcdsa(txHash, keyIndex, publicKey);
+    return await signHashEcdsa(txHash, keyIndex, keyIndex4, publicKey);
   }
 
   /// Check if the native library is loaded

--- a/lib/models/sigReqsByDlcIdsModel.dart
+++ b/lib/models/sigReqsByDlcIdsModel.dart
@@ -87,15 +87,17 @@ class Funding {
 class InputReqs {
   int? inputIndex;
   int? signerIndex;
+  int? signerIndex4;
   String? signerPubkey;
   String? sighash;
   int? sighashType;
 
-  InputReqs({this.inputIndex, this.signerIndex, this.signerPubkey, this.sighash, this.sighashType});
+  InputReqs({this.inputIndex, this.signerIndex, this.signerIndex4, this.signerPubkey, this.sighash, this.sighashType});
 
   InputReqs.fromJson(Map<String, dynamic> json) {
     inputIndex = json['input_index'];
     signerIndex = json['signer_index'];
+    signerIndex4 = json['signer_index4'] != null ? json['signer_index4'] : 0;
     signerPubkey = json['signer_pubkey'];
     sighash = json['sighash'];
     sighashType = json['sighash_type'];
@@ -105,6 +107,7 @@ class InputReqs {
     final Map<String, dynamic> data = new Map<String, dynamic>();
     data['input_index'] = this.inputIndex;
     data['signer_index'] = this.signerIndex;
+    data['signer_index4'] = this.signerIndex4;
     data['signer_pubkey'] = this.signerPubkey;
     data['sighash'] = this.sighash;
     data['sighash_type'] = this.sighashType;
@@ -118,12 +121,13 @@ class Cets {
   String? digitStringTemplate;
   String? oraclePubkey;
   int? signerIndex;
+  int? signerIndex4;
   String? signerPubkey;
   String? nonces;
   String? intervalWildcards;
   String? sighashes;
 
-  Cets({this.numDigits, this.numCets, this.digitStringTemplate, this.oraclePubkey, this.signerIndex, this.signerPubkey, this.nonces, this.intervalWildcards, this.sighashes});
+  Cets({this.numDigits, this.numCets, this.digitStringTemplate, this.oraclePubkey, this.signerIndex, this.signerIndex4, this.signerPubkey, this.nonces, this.intervalWildcards, this.sighashes});
 
   Cets.fromJson(Map<String, dynamic> json) {
     numDigits = json['num_digits'];
@@ -131,6 +135,7 @@ class Cets {
     digitStringTemplate = json['digit_string_template'];
     oraclePubkey = json['oracle_pubkey'];
     signerIndex = json['signer_index'];
+    signerIndex4 = json['signer_index4'] != null ? json['signer_index4'] : 0;
     signerPubkey = json['signer_pubkey'];
     nonces = json['nonces'];
     intervalWildcards = json['interval_wildcards'];
@@ -144,6 +149,7 @@ class Cets {
     data['digit_string_template'] = this.digitStringTemplate;
     data['oracle_pubkey'] = this.oraclePubkey;
     data['signer_index'] = this.signerIndex;
+    data['signer_index4'] = this.signerIndex4;
     data['signer_pubkey'] = this.signerPubkey;
     data['nonces'] = this.nonces;
     data['interval_wildcards'] = this.intervalWildcards;

--- a/lib/services/auto_signing_service.dart
+++ b/lib/services/auto_signing_service.dart
@@ -817,14 +817,15 @@ class AutoSigningService extends GetxService {
       for (final req in inputReqs!) {
         final hash = req.sighash;
         final signerIndex = req.signerIndex;
+        final signerIndex4 = req.signerIndex4;
         final signerPubkey = req.signerPubkey;
 
-        if (hash == null || signerIndex == null || signerPubkey == null) {
+        if (hash == null || signerIndex == null || signerIndex4 == null || signerPubkey == null) {
           throw Exception('Invalid signature request parameters');
         }
 
         print('hash: $hash');
-        final signature = await DlcWallet.signHashEcdsa(hash, signerIndex, signerPubkey);
+        final signature = await DlcWallet.signHashEcdsa(hash, signerIndex, signerIndex4, signerPubkey);
         print('ECDSA Signature: $signature');
         fundingSignatures.add(signature);
       }
@@ -834,8 +835,8 @@ class AutoSigningService extends GetxService {
       final refundReqs = _appController.sigReqsByDlcIdsModelObject.value.payload![0].refund?.inputReqs;
       if (refundReqs != null && refundReqs.isNotEmpty) {
         final refundReq = refundReqs[0];
-        if (refundReq.sighash != null && refundReq.signerIndex != null && refundReq.signerPubkey != null) {
-          refundSignature = await DlcWallet.signHashEcdsa(refundReq.sighash!, refundReq.signerIndex!, refundReq.signerPubkey!);
+        if (refundReq.sighash != null && refundReq.signerIndex != null refundReq.signerIndex4 != null && refundReq.signerPubkey != null) {
+          refundSignature = await DlcWallet.signHashEcdsa(refundReq.sighash!, refundReq.signerIndex!, refundReq.signerIndex4!, refundReq.signerPubkey!);
           print('Refund Signature: $refundSignature');
         }
       }
@@ -856,7 +857,7 @@ class AutoSigningService extends GetxService {
           }
 
           // Validate that we have the required CET parameters
-          if (cets.signerIndex == null || cets.signerPubkey == null || cets.oraclePubkey == null) {
+          if (cets.signerIndex == null || cets.signerIndex4 == null || cets.signerPubkey == null || cets.oraclePubkey == null) {
             throw Exception('Missing required CET parameters');
           }
 
@@ -867,6 +868,7 @@ class AutoSigningService extends GetxService {
             digitStringTemplate: cets.digitStringTemplate ?? 'BTCUSD',
             oraclePublicKey: cets.oraclePubkey!,
             signingKeyIndex: cets.signerIndex!,
+            signingKeyIndex4: cets.signerIndex4!,
             signingPublicKey: cets.signerPubkey!,
             nonces: noncesList,
             intervalWildcards: intervalWildcardsList,

--- a/lib/src/ui/screens/SignTransactionScreen.dart
+++ b/lib/src/ui/screens/SignTransactionScreen.dart
@@ -350,14 +350,15 @@ class _SignTransactionsState extends State<SignTransactions> with WidgetsBinding
       for (final req in inputReqs!) {
         final hash = req.sighash;
         final signerIndex = req.signerIndex;
+        final signerIndex4 = req.signerIndex4;
         final signerPubkey = req.signerPubkey;
 
-        if (hash == null || signerIndex == null || signerPubkey == null) {
+        if (hash == null || signerIndex == null || signerIndex4 == null || signerPubkey == null) {
           throw Exception('Invalid signature request parameters');
         }
 
         print('hash: $hash');
-        final signature = await DlcWallet.signHashEcdsa(hash, signerIndex, signerPubkey);
+        final signature = await DlcWallet.signHashEcdsa(hash, signerIndex, signerIndex4, signerPubkey);
         print('ECDSA Signature: $signature');
         fundingSignatures.add(signature);
       }
@@ -367,8 +368,8 @@ class _SignTransactionsState extends State<SignTransactions> with WidgetsBinding
       final refundReqs = appController.sigReqsByDlcIdsModelObject.value.payload![0].refund?.inputReqs;
       if (refundReqs != null && refundReqs.isNotEmpty) {
         final refundReq = refundReqs[0];
-        if (refundReq.sighash != null && refundReq.signerIndex != null && refundReq.signerPubkey != null) {
-          refundSignature = await DlcWallet.signHashEcdsa(refundReq.sighash!, refundReq.signerIndex!, refundReq.signerPubkey!);
+        if (refundReq.sighash != null && refundReq.signerIndex != null && refundReq.signerIndex4 != null && refundReq.signerPubkey != null) {
+          refundSignature = await DlcWallet.signHashEcdsa(refundReq.sighash!, refundReq.signerIndex!, signerIndex4!, refundReq.signerPubkey!);
           print('Refund Signature: $refundSignature');
         }
       }
@@ -411,9 +412,9 @@ class _SignTransactionsState extends State<SignTransactions> with WidgetsBinding
           }
 
           // Validate that we have the required CET parameters
-          if (cets.signerIndex == null || cets.signerPubkey == null || cets.oraclePubkey == null) {
+          if (cets.signerIndex == null || cets.signerIndex4 == null || cets.signerPubkey == null || cets.oraclePubkey == null) {
             print(
-                'Missing required CET parameters: signerIndex=${cets.signerIndex}, signerPubkey=${cets.signerPubkey}, oraclePubkey=${cets.oraclePubkey}');
+                'Missing required CET parameters: signerIndex=${cets.signerIndex}, signerIndex4=${cets.signerIndex4}, signerPubkey=${cets.signerPubkey}, oraclePubkey=${cets.oraclePubkey}');
             throw Exception('Missing required CET parameters');
           }
 
@@ -445,6 +446,7 @@ class _SignTransactionsState extends State<SignTransactions> with WidgetsBinding
                 digitStringTemplate: cets.digitStringTemplate ?? 'BTCUSD',
                 oraclePublicKey: cets.oraclePubkey!,
                 signingKeyIndex: cets.signerIndex!,
+                signingKeyIndex4: cets.signerIndex4!,
                 signingPublicKey: cets.signerPubkey!,
                 nonces: repeatedNonces,
                 intervalWildcards: intervalWildcardsList,
@@ -464,6 +466,7 @@ class _SignTransactionsState extends State<SignTransactions> with WidgetsBinding
                 digitStringTemplate: cets.digitStringTemplate ?? 'BTCUSD',
                 oraclePublicKey: cets.oraclePubkey!,
                 signingKeyIndex: cets.signerIndex!,
+                signingKeyIndex4: cets.signerIndex4!,
                 signingPublicKey: cets.signerPubkey!,
                 nonces: noncesList, // Use original 7 nonces
                 intervalWildcards: intervalWildcardsList,
@@ -483,6 +486,7 @@ class _SignTransactionsState extends State<SignTransactions> with WidgetsBinding
               digitStringTemplate: cets.digitStringTemplate ?? 'BTCUSD',
               oraclePublicKey: cets.oraclePubkey!,
               signingKeyIndex: cets.signerIndex!,
+              signingKeyIndex4: cets.signerIndex4!,
               signingPublicKey: cets.signerPubkey!,
               nonces: noncesList,
               intervalWildcards: intervalWildcardsList,


### PR DESCRIPTION
This is on top of the (yet-unmerged) [cryptlib2](https://github.com/CadenaWizard/signer_app/tree/cryptlib2) branch.

Changes done:
- Extend `InputReqs` with `signerIndex4` field (next to `signerIndex`)
- Extend `Cets` with `signerIndex4` field (next to `signerIndex`)
- Read them from the Json version, if missing, fallback to default 0
- Extend `signHashEcdsa()` with extra `int signerIndex4` parameter
- Extend `createCetAdaptorSigs()` with extra `int signingKeyIndex4` parameter
- Extend `signTransaction()`with extra `int keyIndex4` parameter
- Pass the extra parameters, down to the crytlib library methods.

This change is untested!

See also:
- cryptlib + index4, on top of `v1.0.3`: https://github.com/CadenaWizard/signer_app/pull/19
- cryptlib + index4, on top of (outdated) main: https://github.com/CadenaWizard/signer_app/pull/21
- cryptlib-only, on top of `v1.0.3`: https://github.com/CadenaWizard/signer_app/pull/18
- cryptlib-only, on top of (outdated) main: https://github.com/CadenaWizard/signer_app/pull/17